### PR TITLE
Add .EditorConfig config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = crlf
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
The rules should be roughly equivalent to whatever was already used.

- Indentation using 4 spaces
- UTF-8 character encoding
- CRLF (\r\n) line endings
- Auto-remove trailing whitespace
- Auto-add trailing newline ([explanation](https://unix.stackexchange.com/a/18789/206873))