### PR TITLE
Improve repository name parsing code; Add "venv" dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ code_duplication/code_duplication_scanner.egg-info/
 code_duplication/dist/
 code_duplication/env/
 code_duplication/repos/
+venv/

--- a/code_duplication/src/common/repo_cloner.py
+++ b/code_duplication/src/common/repo_cloner.py
@@ -2,6 +2,7 @@ from git import Git, Repo
 from os import path, makedirs
 from os.path import isdir, dirname
 from urllib.parse import urlparse
+import re
 from code_duplication import __file__ as base_path
 
 
@@ -16,7 +17,7 @@ def _clone_repo(repo_url):
     # Make sure the base clone dir exists.
     makedirs(clone_dir, exist_ok=True)
 
-    repo_name = urlparse(repo_url).path.split("/")[-1]
+    repo_name = re.sub(r"^.*?/([^/]+?)(?:\.git)?/?$", r"\1", urlparse(repo_url).path)
     repo_dir = path.join(clone_dir, repo_name)
 
     if isdir(repo_dir):


### PR DESCRIPTION
I have no idea why GitHub believes every line has been modified.

The sapacing, encoding and line endings should be exactly the same as before and I have only added a single import and modified line 20 (formerly line 19).