### PR TITLE
Implement an alternative experimental comparison algorithm

### DIFF
--- a/code_duplication/src/common/Nodes/TreeNode.py
+++ b/code_duplication/src/common/Nodes/TreeNode.py
@@ -30,7 +30,7 @@ class TreeNode:
         """
         self.node = node
         self.origin = origin_file + (f" (L:{node.lineno} C:{node.col_offset})"
-                                     if node._attributes else "")
+                                     if node._attributes else f" (ID:{id(node)})")
 
         # HACK: Ignore useless context-related children.
         # This should greatly reduce the total number of nodes.
@@ -102,3 +102,6 @@ class TreeNode:
 
     def __repr__(self):
         return self.__str__()
+
+    def __hash__(self):
+        return hash(self.origin)

--- a/code_duplication/src/common/Nodes/TreeNode.py
+++ b/code_duplication/src/common/Nodes/TreeNode.py
@@ -30,7 +30,7 @@ class TreeNode:
         """
         self.node = node
         self.origin = origin_file + (f" (L:{node.lineno} C:{node.col_offset})"
-                                     if node._attributes else f" (ID:{id(node)})")
+                                     if node._attributes else f" (ID:{id(node):x})")
 
         # HACK: Ignore useless context-related children.
         # This should greatly reduce the total number of nodes.

--- a/code_duplication/src/common/Nodes/TreeNode.py
+++ b/code_duplication/src/common/Nodes/TreeNode.py
@@ -1,5 +1,8 @@
 import ast
 
+_IGNORE_CLASSES = [ast.Load, ast.Store, ast.Del,
+                   ast.AugLoad, ast.AugStore, ast.Param]
+
 
 class TreeNode:
     """
@@ -12,7 +15,7 @@ class TreeNode:
         origin {string} -- Origin of the node (file path, line and column).
         children {List[TreeNode]} -- List of direct children of this node.
         weight {int} -- Total number of nodes in this node's tree.
-        labels {List[string]} -- All labels (names) used in this node's tree.
+        names {List[string]} -- All names / symbols used in this node's tree.
         value {string} -- String representation of just this node.
         index {int} -- Index of this node (in an external flat list of nodes).
         parent_index {int} -- Index of parent node. None if this is root node.
@@ -29,19 +32,26 @@ class TreeNode:
         self.origin = origin_file + (f" (L:{node.lineno} C:{node.col_offset})"
                                      if node._attributes else "")
 
-        self.children = [TreeNode(n, origin_file)
-                         for n in ast.iter_child_nodes(node)]
+        # HACK: Ignore useless context-related children.
+        # This should greatly reduce the total number of nodes.
+        self.children = [TreeNode(n, origin_file) for n in
+                         ast.iter_child_nodes(node)
+                         if n.__class__ not in _IGNORE_CLASSES]
 
         self.weight = 1 + sum([c.weight for c in self.children])
 
-        self.labels = [node.id] if isinstance(node, ast.Name) else []
+        # Name nodes are handled in a special way.
+        if isinstance(node, ast.Name):
+            self.value = f"Name('{node.id}')"
+            self.names = [node.id]
 
-        for c in self.children:
-            self.labels.extend(c.labels)
+        else:
+            # Class name if the node has children, AST dump if it does not.
+            self.value = node.__class__.__name__ if self.children else self.dump()
 
-        # Class name if the node has children, AST dump if it does not.
-        self.value = node.id if isinstance(node, ast.Name) else \
-            node.__class__.__name__ if self.children else self.dump()
+            self.names = []
+            for c in self.children:
+                self.names.extend(c.names)
 
         # These values are set externally after all nodes are parsed
         # during the node tree flattening process.

--- a/code_duplication/src/common/benchmark.py
+++ b/code_duplication/src/common/benchmark.py
@@ -1,0 +1,17 @@
+from time import time
+
+_last_time = time()
+
+
+def time_snap(text=None):
+    """
+    Prints the time since the last call to this function in seconds.
+    It is possible to supply a message to print along with the time.
+
+    Arguments:
+        text {str} (optional) -- Message to print with the time.
+    """
+    global _last_time
+    current_time = time()
+    print(current_time - _last_time, "seconds -", text)
+    _last_time = current_time

--- a/code_duplication/src/common/comparer.py
+++ b/code_duplication/src/common/comparer.py
@@ -1,0 +1,89 @@
+from .Nodes.TreeNode import TreeNode
+from .repo_cloner import _clone_repo
+from .module_parser import get_modules_from_dir
+
+
+def _get_skeleton(node, child_skeletons):
+    return f"{node.value}[{', '.join(child_skeletons)}]" if child_skeletons \
+        else node.value
+
+
+def _get_skeleton_recursive(node):
+    return _get_skeleton(node, [_get_skeleton_recursive(c) for c in node.children])
+
+
+def _type1_compare(node1, node2):
+    if node1.value != node2.value or node1.weight != node2.weight:
+        return 0, f"Hole({(node1.weight + node2.weight) / 2 :g})"
+
+    if node1.dump() == node2.dump():
+        return node1.weight, _get_skeleton_recursive(node1)
+
+    match_weight = 1
+    child_skeletons = []
+
+    if len(node1.children) == len(node2.children):
+        for i, c in enumerate(node1.children):
+            pair_weight, pair_skeleton = _type1_compare(c, node2.children[i])
+
+            match_weight += pair_weight
+            child_skeletons.append(pair_skeleton)
+
+    return match_weight, _get_skeleton(node1, child_skeletons)
+
+
+# def _type1_check(modules):
+#     """
+#     Very simple type 1 code duplication check based on AST.dump() function.
+#     """
+
+#     WEIGHT_LIMIT = 25
+
+#     node_dict = {}
+
+#     for m in modules:
+#         visited = set()
+
+#         for n in m:
+#             if n.parent_index in visited or n.weight < WEIGHT_LIMIT:
+#                 visited.add(n.index)
+#                 continue
+
+#             node_dump = n.dump()
+
+#             if node_dump in node_dict:
+#                 visited.add(n.index)
+#                 node_dict[node_dump].append(n)
+#             else:
+#                 node_dict[node_dump] = [n]
+
+#     for v in node_dict.values():
+#         if len(v) > 1:
+#             print(v)
+
+
+def find_clones_in_repo(repo_url):
+    repo_dir = _clone_repo(repo_url)
+    repo_modules = get_modules_from_dir(repo_dir)
+    # _type1_check(repo_modules)
+
+    nodes = []
+
+    for m in repo_modules:
+        nodes.extend(m)
+
+    for i1, n1 in enumerate(nodes):
+        for i2 in range(i1 + 1, len(nodes)):
+            n2 = nodes[i2]
+
+            if n1.weight != n2.weight or n1.weight < 30:
+                continue
+
+            total_weight = n1.weight
+            match_weight, match_skeleton = _type1_compare(n1, n2)
+
+            match_percentage = round(match_weight / total_weight * 100, 2)
+
+            if match_percentage > 75:
+                print(
+                    f"\n{match_skeleton}\n\n{n1}\n{n2}\nSimilarity: {match_percentage} % ({match_weight} out of {total_weight} nodes)")

--- a/code_duplication/src/common/comparer.py
+++ b/code_duplication/src/common/comparer.py
@@ -1,8 +1,27 @@
 from .repo_cloner import _clone_repo
 from .module_parser import get_modules_from_dir
+from .benchmark import time_snap
 
 _MIN_WEIGHT = 80
 _MIN_MATCH_PERCENTAGE = 80
+
+
+def _flatten(list_of_lists):
+    flat = []
+
+    for l in list_of_lists:
+        flat.extend(l)
+
+    return flat
+
+
+def _get_all_children(node):
+    children = node.children
+
+    for c in children:
+        children.extend(_get_all_children(c))
+
+    return children
 
 
 def _get_skeleton(node_value, child_skeletons):
@@ -41,10 +60,13 @@ def _type1_compare(node1, node2):
 
 
 def find_clones_in_repo(repo_url):
+    time_snap("Start of function")
     repo_dir = _clone_repo(repo_url)
+    time_snap("Repository cloned")
     repo_modules = get_modules_from_dir(repo_dir)
 
     nodes = [m[0] for m in repo_modules]
+    time_snap("Modules / nodes parsed")
 
     ignore_dict = {}
     start = 0
@@ -70,7 +92,7 @@ def find_clones_in_repo(repo_url):
                     continue
 
                 total_weight = n1.weight + n2.weight
-                if total_weight < 50:
+                if total_weight < _MIN_WEIGHT:
                     continue
 
                 match_weight, match_skeleton = _type1_compare(n1, n2)
@@ -94,3 +116,62 @@ def find_clones_in_repo(repo_url):
                     ignore_dict[index] = ignore_set.copy()
 
         start = end
+
+    time_snap("End of function")
+
+
+def compare_two_repos(repo1_url, repo2_url):
+    time_snap("Function start")
+    repo1_dir = _clone_repo(repo1_url)
+    time_snap("Clone first")
+    repo2_dir = _clone_repo(repo2_url)
+    time_snap("Clone second")
+    repo1_modules = get_modules_from_dir(repo1_dir)
+    time_snap("Get modules from first")
+    repo2_modules = get_modules_from_dir(repo2_dir)
+    time_snap("Get modules from second")
+    repo1_nodes = [m[0] for m in repo1_modules]
+    repo2_nodes = _flatten(repo2_modules)
+    time_snap("Convert modules into nodes")
+
+    ignore_dict = {}
+    start = 0
+
+    while start < len(repo1_nodes):
+        end = len(repo1_nodes)
+
+        for i1 in range(start, end):
+            n1 = repo1_nodes[i1]
+            ignore_set = ignore_dict.pop(i1, set())
+
+            for n2 in repo2_nodes:
+                if not _can_be_compared(n1, n2):
+                    continue
+
+                total_weight = n1.weight + n2.weight
+                if total_weight < _MIN_WEIGHT:
+                    continue
+
+                match_weight, match_skeleton = _type1_compare(n1, n2)
+                if not match_weight:
+                    continue
+
+                match_percentage = round(match_weight / total_weight * 100, 2)
+
+                if match_percentage >= _MIN_MATCH_PERCENTAGE:
+                    print(f"\n{match_skeleton}\n\n{n1}\n{n2}\n" +
+                          f"Similarity: {match_percentage:g} % ({match_weight} out of {total_weight} nodes)")
+
+                if match_weight == total_weight:
+                    ignore_set.update(n2.children)
+
+            first_index = len(repo1_nodes)
+            repo1_nodes.extend(n1.children)
+
+            if ignore_set:
+                for i in range(first_index, len(repo1_nodes)):
+                    ignore_dict[i] = ignore_set.copy()
+
+        start = end
+
+    time_snap("End of function")


### PR DESCRIPTION
To avoid further confusion, `TreeNode.labels` has been renamed to `TreeNode.names`. We may not need it at all in the end and it has been causing unnecessary confusion due to the poor choice of terminology in the used paper.