### PR TITLE
Implement partial repository matching (user-friendlier repo search)

### DIFF
--- a/engine/algorithms/chlorine/chlorine.py
+++ b/engine/algorithms/chlorine/chlorine.py
@@ -125,7 +125,7 @@ def _dict_to_result(match_dict, skeleton_weight_dict):
     for k, v in match_dict.items():
         origin_list = list(v)
         clones.append(DetectedClone(
-            origin_list[0].value, skeleton_weight_dict[k], origin_list))
+            origin_list[0].value, skeleton_weight_dict[k], nodes=origin_list))
 
     return DetectionResult(clones)
 

--- a/engine/algorithms/iodine/iodine.py
+++ b/engine/algorithms/iodine/iodine.py
@@ -28,6 +28,7 @@ def iodine(module_list_1, module_list_2):
     for cluster_list in clusters:
         for pattern in cluster_list:
             if pattern:
-                clones.append(DetectedClone(pattern[0].value, pattern[0].get_match_weight(), pattern[0].nodes))
+                clones.append(DetectedClone(
+                    pattern[0].value, pattern[0].get_match_weight(), nodes=pattern[0].nodes))
 
     return DetectionResult(clones)

--- a/engine/algorithms/oxygen/oxygen.py
+++ b/engine/algorithms/oxygen/oxygen.py
@@ -47,6 +47,6 @@ def oxygen(modules, weight_limit=15):
             continue
 
         clones.append(DetectedClone(
-            origin_list[0].value, origin_list[0].weight, origin_list))
+            origin_list[0].value, origin_list[0].weight, nodes=origin_list))
 
     return DetectionResult(clones)

--- a/engine/errors/analysis.py
+++ b/engine/errors/analysis.py
@@ -1,0 +1,23 @@
+"""Module containing the `AnalysisError` exception class."""
+
+
+class AnalysisError(Exception):
+    """
+    Exception representing an error during a repository analysis.
+
+    Attributes:
+        message {string} -- Message explaining what went wrong.
+
+    """
+
+    def __init__(self, message):
+        """
+        Initialize a analysis error instance.
+
+        Arguments:
+            message {string} -- Message explaining what went wrong.
+
+        """
+        super().__init__(message)
+
+        self.message = message

--- a/engine/errors/user_input.py
+++ b/engine/errors/user_input.py
@@ -24,5 +24,7 @@ class UserInputError(Exception):
             code {int} -- Preferred exit code (only if application exits).
 
         """
+        super().__init__(message, code)
+
         self.message = message
         self.code = code

--- a/engine/preprocessing/repoinfo.py
+++ b/engine/preprocessing/repoinfo.py
@@ -88,7 +88,7 @@ class RepoInfo:
             return None
 
         path_match = re.fullmatch(
-            r"/*([\w\-\.]+)/*([\w\-\.]+?)(?:\.git)?/*", parts.path)
+            r"^/*([\w\-\.]+)/+([\w\-\.]+?)(?:\.git)?/*$", parts.path)
 
         if not path_match:
             # If there is no scheme, try to prepend HTTPS

--- a/engine/results/detected_clone.py
+++ b/engine/results/detected_clone.py
@@ -12,25 +12,39 @@ class DetectedClone:
     Attributes:
         value {string} -- String representation common to all the nodes.
         match_weight {int} -- Weight of the matching subtree skeleton.
-        origins {dict[string: float]} -- Origins and similarity coefficients.
+        origins {dict[NodeOrigin: float]} -- Origins and similarity coefficients.
                                          Origins are used for keys.
                                          Similarity coefficients are values.
 
     """
 
-    def __init__(self, value, match_weight, nodes):
+    def __init__(self, value, match_weight, origins=None, nodes=None):
         """
         Initialize a new detected clone given its values and origin nodes.
+
+        It is possible to either supply a dictionary of origins
+        (this is useful when recreating a detected clone instance)
+        or a list of list of origin TreeNodes, which is more useful right
+        after running a clone detection algorithm, which produces them.
+
+        See class docstring for details on constructor arguments.
 
         Arguments:
             value {string} -- String representation common to all the nodes.
             match_weight {int} -- Weight of the matching subtree skeleton.
+            origins {dict[NodeOrigin: float]} -- Origins and similarity coefficients.
+                                             Origins are used for keys.
+                                             Similarity coefficients are values.
             nodes {list[TreeNode]} -- List of origin nodes.
 
         """
+        if origins is None == nodes is None:
+            raise ValueError("Either origins or nodes must be non-None")
+
         self.value = value
         self.match_weight = match_weight
-        self.origins = {n.origin: match_weight / n.weight for n in nodes}
+        self.origins = origins or \
+            {n.origin: match_weight / n.weight for n in nodes}
 
     def dict(self):
         """

--- a/engine/results/detection_result.py
+++ b/engine/results/detection_result.py
@@ -25,7 +25,7 @@ class DetectionResult:
         The original list of clones will not be modified in any way.
 
         Arguments:
-            clones {list[Detectedlone]} -- List of detected code clones.
+            clones {list[DetectedClone]} -- List of detected code clones.
 
         """
         self.clones = clones.copy()

--- a/web/analyzer.py
+++ b/web/analyzer.py
@@ -210,14 +210,18 @@ def get_repo_analysis(repo_path):
             if re.fullmatch(r"^[\w\.\-]+$", repo_path):
                 repos = _find_repos_by_metadata(conn, repo_path)
 
-                # TODO: If exactly one repository has been found, process it
-                # in the same way as if a normal path was specified.
-                if repos:
-                    return repos
-
-                else:
+                # No repository matches the given repository path.
+                if not repos:
                     raise UserInputError(
                         "No matching repository found in the database")
+
+                # Exact one matching repository.
+                if len(repos) == 1:
+                    return _get_repo_summary(conn, repos[0])
+
+                # Multiple repositories match the repository path.
+                else:
+                    return repos
 
             else:
                 raise UserInputError("Invalid Git repository path format")

--- a/web/index.mako
+++ b/web/index.mako
@@ -60,6 +60,31 @@
         </div>
         % endif
 
+        % if repos:
+        <div class="row">
+            <div class="col s6 offset-s3">
+                <ul class="collection with-header">
+                    <li class="collection-header">
+                        <h4>
+                            Matching repositories
+                        </h4>
+                    </li>
+
+                    % for r in repos:
+                    <li class="collection-item">
+                        <h5><a href="?repo=https%3A%2F%2F${r.server}%2F${r.user}%2F${r.name}">${r.name}</a></h5>
+                        <b>URL:</b> <a href="${r.url}">${r.url}</a><br>
+                        <b>Server:</b> <a href="https://${r.server}">${r.server}</a><br>
+                        <b>User:</b> <a href="https://${r.server}/${r.user}">${r.user}</a><br>
+                        <b>Status:</b> ${r.status_desc or r.status_name}
+                    </li>
+                    % endfor
+
+                </ul>
+            </div>
+        </div>
+        % endif
+
         % if clones:
         <div class="row">
             <div class="col s8 offset-s2">
@@ -75,13 +100,13 @@
                         <ul class="collection with-header">
                             <li class="collection-header">
                                 <h5>
-                                    ${c.value} - Weight: ${c.weight}
+                                    ${c.value} - Weight: ${c.match_weight}
                                 </h5>
                             </li>
 
-                            % for o in c.origins:
+                            % for o, s in c.origins.items():
                             <li class="collection-header">
-                                ${o[0]} - Similarity: ${format(o[1] * 100, "g")} %
+                                ${o} - Similarity: ${format(s * 100, "g")} %
                             </li>
                             % endfor
 


### PR DESCRIPTION
If no exact match is found for the repository path, the web backend will attempt to find a partial match (repo name - `codeDuplicationParser`, repo's owner's username - `calebdehaan`, server name - `github.com`) in the repository database (therefore this only works with previously analyzed repositories).

If there is exactly one partial match, the user will be presented with that repo's analysis. This will typically be the case when the user enters an exact repository name unless different repositories with the same name (most likely forks) have been analyzed.

See #105 for a (relatively small) problem that stems from this.

If there are multiple partially matching repositories, the user will be presented with a list of matching repositories instead. This will likely be the case when the user enters a username or a server name. The list contains the repositories' names, links to their analysis pages, links to the repository itself, their host server, the repository owner's profile and the status of the analysis.

Close #99 
Close #100 